### PR TITLE
Removing the restriction to use a maximum version of staging module. 

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -19,7 +19,7 @@
   "project_page": "https://github.com/theyosef/puppet-nxlog",
   "dependencies": [
     { 
-      "name": "nanliu/staging", "version_requirement": ">=0.4.1 <0.5.0" 
+      "name": "nanliu/staging", "version_requirement": ">=0.4.1" 
     }
   ]
 }


### PR DESCRIPTION
causing dependency issues when both staging and nxlog module is used with different versions.
